### PR TITLE
[D10-59] claim D10 compatibility

### DIFF
--- a/flysystem_ocfl.info.yml
+++ b/flysystem_ocfl.info.yml
@@ -2,6 +2,6 @@
 name: Flysystem OCFL
 description: Flysystem adapter supporting reading from OCFL storages.
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - flysystem:flysystem


### PR DESCRIPTION
This is naively claiming drupal 10 compatibility, so we can at least install the module to check functional compatibility.